### PR TITLE
Feat policy calbacks should unwrap the lazy

### DIFF
--- a/LazyCache.UnitTests/LazyCache.UnitTests.csproj
+++ b/LazyCache.UnitTests/LazyCache.UnitTests.csproj
@@ -61,6 +61,9 @@
       <Name>LazyCache</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/LazyCache.UnitTests/ServiceCacheTests.cs
+++ b/LazyCache.UnitTests/ServiceCacheTests.cs
@@ -453,13 +453,14 @@ namespace LazyCache.UnitTests
             Func<int> fetch = () => 123;
             CacheEntryRemovedArguments removedCallbackArgs = null;
             CacheEntryRemovedCallback callback = (args) => removedCallbackArgs = args;
+            
+            
             sut.GetOrAdd(TestKey, fetch, new CacheItemPolicy { AbsoluteExpiration = DateTimeOffset.Now.AddMilliseconds(100), RemovedCallback = callback});
             var actual = sut.Get<int>(TestKey);
             
             sut.Remove(TestKey); //force removed callback to fire
             while(removedCallbackArgs == null)
-                Thread.Sleep(100);
-            
+                Thread.Sleep(500);
             
             Assert.AreEqual(123, removedCallbackArgs.CacheItem.Value); 
         }
@@ -475,7 +476,7 @@ namespace LazyCache.UnitTests
 
             sut.Remove(TestKey); //force removed callback to fire
             while (removedCallbackArgs == null)
-                Thread.Sleep(100);
+                Thread.Sleep(500);
 
             Assert.AreEqual(123, removedCallbackArgs.CacheItem.Value);
         }

--- a/LazyCache.UnitTests/ServiceCacheTests.cs
+++ b/LazyCache.UnitTests/ServiceCacheTests.cs
@@ -445,5 +445,39 @@ namespace LazyCache.UnitTests
             sut.Remove(TestKey);
             Assert.Null(sut.Get<object>(TestKey));
         }
+
+        [Test, Timeout(20000)]
+        public void GetOrAddWithPolicyWithCallbackOnRemovedReturnsTheOriginalCachedObject()
+        {
+            var sut = new CachingService();
+            Func<int> fetch = () => 123;
+            CacheEntryRemovedArguments removedCallbackArgs = null;
+            CacheEntryRemovedCallback callback = (args) => removedCallbackArgs = args;
+            sut.GetOrAdd(TestKey, fetch, new CacheItemPolicy { AbsoluteExpiration = DateTimeOffset.Now.AddMilliseconds(100), RemovedCallback = callback});
+            var actual = sut.Get<int>(TestKey);
+            
+            sut.Remove(TestKey); //force removed callback to fire
+            while(removedCallbackArgs == null)
+                Thread.Sleep(100);
+            
+            
+            Assert.AreEqual(123, removedCallbackArgs.CacheItem.Value); 
+        }
+
+        [Test, Timeout(20000)]
+        public void GetOrAddWithCallbackOnRemovedReturnsTheOriginalCachedObjectEvenIfNotGettedBeforehand()
+        {
+            var sut = new CachingService();
+            Func<int> fetch = () => 123;
+            CacheEntryRemovedArguments removedCallbackArgs = null;
+            CacheEntryRemovedCallback callback = (args) => removedCallbackArgs = args;
+            sut.GetOrAdd(TestKey, fetch, new CacheItemPolicy { AbsoluteExpiration = DateTimeOffset.Now.AddMilliseconds(100), RemovedCallback = callback });
+
+            sut.Remove(TestKey); //force removed callback to fire
+            while (removedCallbackArgs == null)
+                Thread.Sleep(100);
+
+            Assert.AreEqual(123, removedCallbackArgs.CacheItem.Value);
+        }
     }
 }

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -100,6 +100,24 @@ namespace LazyCache
 
             var newLazyCacheItem = new Lazy<T>(addItemFactory);
 
+            if (policy != null && policy.RemovedCallback != null)
+            {
+                policy.RemovedCallback = (args) =>
+                {
+                    //unwrap the cache item in a removed callback given one is specified
+                    if (args != null && args.CacheItem != null)
+                    {
+                        var item = args.CacheItem.Value;
+                        if (item is Lazy<T>)
+                        {
+                            var lazyCacheItem = (Lazy<T>) item;
+                            args.CacheItem.Value = lazyCacheItem.IsValueCreated ? item : null;
+                        }
+                    }
+                    policy.RemovedCallback(args);
+                };
+            }
+
             var existingCacheItem = cache.AddOrGetExisting(key, newLazyCacheItem, policy);
 
             if (existingCacheItem != null)

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -100,23 +100,7 @@ namespace LazyCache
 
             var newLazyCacheItem = new Lazy<T>(addItemFactory);
 
-            if (policy != null && policy.RemovedCallback != null)
-            {
-                policy.RemovedCallback = (args) =>
-                {
-                    //unwrap the cache item in a removed callback given one is specified
-                    if (args != null && args.CacheItem != null)
-                    {
-                        var item = args.CacheItem.Value;
-                        if (item is Lazy<T>)
-                        {
-                            var lazyCacheItem = (Lazy<T>) item;
-                            args.CacheItem.Value = lazyCacheItem.IsValueCreated ? item : null;
-                        }
-                    }
-                    policy.RemovedCallback(args);
-                };
-            }
+            EnsureRemovedCallbackDoesNotReturnTheLazy<T>(policy);
 
             var existingCacheItem = cache.AddOrGetExisting(key, newLazyCacheItem, policy);
 
@@ -143,6 +127,28 @@ namespace LazyCache
             {
                 cache.Remove(key);
                 throw;
+            }
+        }
+
+        private static void EnsureRemovedCallbackDoesNotReturnTheLazy<T>(CacheItemPolicy policy)
+        {
+            if (policy != null && policy.RemovedCallback != null)
+            {
+                var originallCallback = policy.RemovedCallback;
+                policy.RemovedCallback = (args) =>
+                {
+                    //unwrap the cache item in a callback given one is specified
+                    if (args != null && args.CacheItem != null)
+                    {
+                        var item = args.CacheItem.Value;
+                        if (item is Lazy<T>)
+                        {
+                            var lazyCacheItem = (Lazy<T>) item;
+                            args.CacheItem.Value = lazyCacheItem.IsValueCreated ? lazyCacheItem.Value : default(T);
+                        }
+                    }
+                    originallCallback(args);
+                };
             }
         }
 

--- a/LazyCache/Properties/AssemblyInfo.cs
+++ b/LazyCache/Properties/AssemblyInfo.cs
@@ -33,5 +33,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.5.6.0")]
-[assembly: AssemblyFileVersion("0.5.6.0")]
+[assembly: AssemblyVersion("0.6.0.0")]
+[assembly: AssemblyFileVersion("0.6.0.0")]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Lazy Cache #
 
-Lazy cache is a simple in-memory caching service. It has a developer friendly generics based API, and providing a thread safe cache implementation that  guarantees to only execute your cachable delegates once (it's lazy!). Under the hood it leverages ObjectCache and Lazy<T> to provide performance and reliability in heavy load scenarios
+Lazy cache is a simple in-memory caching service. It has a developer friendly 
+generics based API, and provides a thread safe cache implementation that 
+guarantees to only execute your cachable delegates once (it's lazy!). Under 
+the hood it leverages ObjectCache and Lazy<T> to provide performance and 
+reliability in heavy load scenarios.
 
 ## Download ##
 
@@ -11,14 +15,15 @@ LazyCache is available using [nuget](https://www.nuget.org/packages/LazyCache/).
 
 ## Sample code ##
 
-    // Create our cache service using the defaults (Dependency injection would be better).
-    // Uses MemoryCache.Default under the hood so cache is shared
+    // Create our cache service using the defaults (Dependency injection ready).
+    // Uses MemoryCache.Default under the hood so cache is shared out of the box
     IAppCache cache = new CachingService();
 
-    // Declare (but don't execute) a func whose result we want to cache
+    // Declare (but don't execute) a func/delegate whose result we want to cache
     Func<ComplexObects> complexObjectFactory = () => methodThatTakesTimeOrResources();
     
-    // Get our ComplexObjects from the cache, or build them in the factory func and cache the results for next time
+    // Get our ComplexObjects from the cache, or build them in the factory func 
+    // and cache the results for next time under the given key
     ComplexObject cachedResults = cache.GetOrAdd("uniqueKey", complexObjectFactory);
     
 As you can see the magic happens in the `GetOrAdd()` method which gives the consumer an atomic and tidy way to add caching to your code. It leverages a factory delegate `Func` and generics to make it easy to add cached method calls to your app. 
@@ -37,7 +42,7 @@ Suits the caching of database calls, complex object graph building routines and 
 - Thread safe, concurrency ready
 - Interface based API and built in `MockCache` to support test driven development and dependency injection
 - Leverages ObjectCache under the hood and can be extended with your own implementation of ObjectCache
-- The main class `CachingSevice` is a single class and so could be simply embedded
+- The main class `CachingSevice` is a single class and so could be easily embedded in your application or library
 - Good test coverage
 
 ## API Documentation

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release notes for LazyCache #
 
+## Version 0.6 ##
+
+- Fixed issue with RemovedCallback not unwrapping the Lazy used to thread safe the cache item.
+
 ## Version 0.5 ##
 
 - Initial release of CachingService and interface IAppCache. 


### PR DESCRIPTION
Fixes #1
prevents stack overflow exception and uses the value in the Lazy object to unwrap and set the cache item value