### PR TITLE
Add Default CacheDefaults for MockCachingService

### DIFF
--- a/LazyCache.UnitTests/MockCachingServiceTests.cs
+++ b/LazyCache.UnitTests/MockCachingServiceTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using FluentAssertions;
+using LazyCache.Mocks;
+using Microsoft.Extensions.Caching.Memory;
+using NUnit.Framework;
+
+namespace LazyCache.UnitTests
+{
+    public class MockCachingServiceTests
+    {
+        private const string CacheKey = "cacheKey";
+        private const string FunctionReturnValue = "someValue";
+
+        [Test]
+        public void GetOrAddCalledWithCacheKeyAndFunction_FunctionResultReturned()
+        {
+            var sut = new MockCachingService();
+
+            var result = sut.GetOrAdd(CacheKey, () => FunctionReturnValue);
+
+            result.Should().Be(FunctionReturnValue);
+        }
+
+        [Test]
+        public void GetOrAddCalledWithCacheKeyAndFunctionWithCacheEntry_FunctionResultReturned()
+        {
+            var sut = new MockCachingService();
+
+            var result = sut.GetOrAdd(CacheKey, cacheEntry => FunctionReturnValue);
+
+            result.Should().Be(FunctionReturnValue);
+        }
+
+        [Test]
+        public void GetOrAddCalledWithCacheKeyAndFunctionWithDateTimeOffSet_FunctionResultReturned()
+        {
+            var sut = new MockCachingService();
+
+            var result = sut.GetOrAdd(CacheKey, () => FunctionReturnValue, DateTimeOffset.MinValue);
+
+            result.Should().Be(FunctionReturnValue);
+        }
+
+        [Test]
+        public void GetOrAddCalledWithCacheKeyAndFunctionWithMemoryCacheEntryOptions_FunctionResultReturned()
+        {
+            var sut = new MockCachingService();
+
+            var result = sut.GetOrAdd(CacheKey, () => FunctionReturnValue, new MemoryCacheEntryOptions());
+
+            result.Should().Be(FunctionReturnValue);
+        }
+
+        [Test]
+        public void GetOrAddCalledWithCacheKeyAndFunctionWithTimeSpan_FunctionResultReturned()
+        {
+            var sut = new MockCachingService();
+
+            var result = sut.GetOrAdd(CacheKey, () => FunctionReturnValue, TimeSpan.FromMilliseconds(1000));
+
+            result.Should().Be(FunctionReturnValue);
+        }
+    }
+}

--- a/LazyCache/Mocks/MockCachingService.cs
+++ b/LazyCache/Mocks/MockCachingService.cs
@@ -11,7 +11,7 @@ namespace LazyCache.Mocks
     public class MockCachingService : IAppCache
     {
         public ICacheProvider CacheProvider { get; } = new MockCacheProvider();
-        public CacheDefaults DefaultCachePolicy { get; set; }
+        public CacheDefaults DefaultCachePolicy { get; set; } = new CacheDefaults();
 
         public T Get<T>(string key)
         {


### PR DESCRIPTION
When used with extension methods provided in `AppCacheExtensions`, `MockCachingService` would throw a null reference exception. I've added a default to `DefaultCachePolicy` to prevent that.

I've also included a few tests to cover this.