### PR TITLE
Cache invalidation with partial key knowledge

### DIFF
--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -754,6 +755,34 @@ namespace LazyCache.UnitTests
             Assert.NotNull(sut.Get<object>(TestKey));
             sut.Remove(TestKey);
             Assert.Null(sut.Get<object>(TestKey));
+        }
+
+        [Test]
+        public void RemovedItemWithCompositeKeyCannotBeRetrievedFromCache()
+        {
+            var internalTestKey1 = TestKey + ".1";
+            var internalTestKey2 = TestKey + ".2";
+            var internalTestKey3 = "1." + TestKey;
+
+            IEnumerable<string> CompositeKeyTest(IEnumerable<string> keys)
+            {
+                return keys.Where(a => a.StartsWith(TestKey));
+            }
+
+            sut.Add(internalTestKey1, new object());
+            sut.Add(internalTestKey2, new object());
+            sut.Add(internalTestKey3, new object());
+            Assert.NotNull(sut.Get<object>(internalTestKey1));
+            Assert.NotNull(sut.Get<object>(internalTestKey2));
+            Assert.NotNull(sut.Get<object>(internalTestKey3));
+
+            sut.Remove(CompositeKeyTest);
+            Assert.Null(sut.Get<object>(internalTestKey1));
+            Assert.Null(sut.Get<object>(internalTestKey2));
+            Assert.NotNull(sut.Get<object>(internalTestKey3));
+
+            sut.Remove(internalTestKey3);
+            Assert.Null(sut.Get<object>(internalTestKey3));
         }
     }
 }

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -122,6 +122,13 @@ namespace LazyCache
             CacheProvider.Remove(key);
         }
 
+        public virtual void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate)
+        {
+            if (keyPredicate == null)
+                throw new ArgumentNullException(nameof(keyPredicate));
+            CacheProvider.Remove(keyPredicate);
+        }
+
         public virtual ICacheProvider CacheProvider => cacheProvider.Value;
 
         public virtual async Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory)

--- a/LazyCache/IAppCache.cs
+++ b/LazyCache/IAppCache.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -24,5 +25,7 @@ namespace LazyCache
         Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory);
 
         void Remove(string key);
+
+        void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate);
     }
 }

--- a/LazyCache/ICacheProvider.cs
+++ b/LazyCache/ICacheProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -10,6 +11,7 @@ namespace LazyCache
         object Get(string key);
         object GetOrCreate<T>(string key, Func<ICacheEntry, T> func);
         void Remove(string key);
+        void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate);
         Task<T> GetOrCreateAsync<T>(string key, Func<ICacheEntry, Task<T>> func);
     }
 }

--- a/LazyCache/Mocks/MockCacheProvider.cs
+++ b/LazyCache/Mocks/MockCacheProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -21,6 +22,10 @@ namespace LazyCache.Mocks
         }
 
         public void Remove(string key)
+        {
+        }
+
+        public void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate)
         {
         }
 

--- a/LazyCache/Mocks/MockCachingService.cs
+++ b/LazyCache/Mocks/MockCachingService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -24,6 +25,10 @@ namespace LazyCache.Mocks
         }
 
         public void Remove(string key)
+        {
+        }
+
+        public void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate)
         {
         }
 

--- a/LazyCache/Providers/MemoryCacheProvider.cs
+++ b/LazyCache/Providers/MemoryCacheProvider.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -7,39 +9,66 @@ namespace LazyCache.Providers
     public class MemoryCacheProvider : ICacheProvider
     {
         internal readonly IMemoryCache cache;
+        private List<string> _keys;
 
         public MemoryCacheProvider(IMemoryCache cache)
         {
             this.cache = cache;
+            _keys = new List<string>();
         }
 
         public void Set(string key, object item, MemoryCacheEntryOptions policy)
         {
+            _keys.Add(key);
             cache.Set(key, item, policy);
         }
 
         public object Get(string key)
         {
-            return cache.Get(key);
+            var attemptedResult = cache.TryGetValue(key, out var result);
+
+            //Remove the key from the key cache if it exists and this didn't return a result
+            if (attemptedResult == false && _keys.Contains(key))
+                _keys.Remove(key);
+
+            return result;
         }
 
         public object GetOrCreate<T>(string key, Func<ICacheEntry, T> factory)
         {
+            if (!_keys.Contains(key))
+                _keys.Add(key);
+
             return cache.GetOrCreate(key, factory);
         }
 
         public void Remove(string key)
         {
+            _keys.Remove(key);
             cache.Remove(key);
+        }
+
+        public void Remove(Func<IEnumerable<string>, IEnumerable<string>> keyPredicate)
+        {
+            //Search the keys for any matches to the predicate
+            var keyMatches = keyPredicate(_keys).ToList();
+
+            //Remove each of the matches
+            foreach (var match in keyMatches) 
+                Remove(match);
         }
 
         public Task<T> GetOrCreateAsync<T>(string key, Func<ICacheEntry, Task<T>> factory)
         {
+            if (!_keys.Contains(key))
+                _keys.Add(key);
+
             return cache.GetOrCreateAsync(key, factory);
         }
 
         public void Dispose()
         {
+            _keys = null;
             cache?.Dispose();
         }
     }


### PR DESCRIPTION
Per the issue I opened just a brief while ago at [https://github.com/alastairtree/LazyCache/issues/86](https://github.com/alastairtree/LazyCache/issues/86), this pull request is a first pass at an implementation supporting cache invalidation without knowing the entirety of the key.

Since it requires knowledge of the various keys in the cache, I implemented a non-authoritative list of keys that attempt to update along with the various cache operations, but also thus allow for a predicate function to iterate through each of the keys for matches based on partial key knowledge.

This enables a scenario where I have a user identified by a value and want to cache the result of an operation based on the values of any of the parameters to the method. The current LazyCache implementation easily supports the addition of keys to this end, but should I modify any of the data, I may want to invalidate all keys referencing this user even though that identifier is only part of a larger composite. 

My pull request enables the user to define a Func that iterates through all the keys that are presumably in the cache to select those to remove, despite lacking the information necessary to produce the whole cached key. I'd appreciate any feedback you have about this.