### PR TITLE
bug: if you change the type of the cache item the old item gets evicted

### DIFF
--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -253,6 +253,15 @@ namespace LazyCache.UnitTests
         }
 
         [Test]
+        public void GetOrAddAndThenGetOrAddDifferentTypeDoesLastInWins()
+        {
+            var first = sut.GetOrAdd(TestKey, () => new object());
+            var second = sut.GetOrAdd(TestKey, () => testObject);
+            Assert.IsNotNull(second);
+            Assert.IsInstanceOf<ComplexTestObject>(second);
+        }
+
+        [Test]
         public void GetOrAddAndThenGetValueObjectReturnsCorrectType()
         {
             sut.GetOrAdd(TestKey, () => 123);
@@ -267,6 +276,8 @@ namespace LazyCache.UnitTests
             var actual = sut.Get<ApplicationException>(TestKey);
             Assert.IsNull(actual);
         }
+
+
 
         [Test]
         public void GetOrAddAsyncACancelledTaskDoesNotCacheIt()
@@ -313,6 +324,15 @@ namespace LazyCache.UnitTests
             var actual = await sut.GetAsync<ComplexTestObject>(TestKey);
             Assert.IsNotNull(actual);
             Assert.That(actual, Is.EqualTo(testObject));
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncAndThenGetOrAddAsyncDifferentTypeDoesLastInWins()
+        {
+            var first = await sut.GetOrAddAsync(TestKey, () => Task.FromResult(new object()));
+            var second = await sut.GetOrAddAsync(TestKey, () => Task.FromResult(testObject));
+            Assert.IsNotNull(second);
+            Assert.IsInstanceOf<ComplexTestObject>(second);
         }
 
         [Test]

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -71,7 +71,7 @@ namespace LazyCache
 
             var item = CacheProvider.Get(key);
 
-            return GetValueFromLazy<T>(item);
+            return GetValueFromLazy<T>(item, out _);
         }
 
         public virtual Task<T> GetAsync<T>(string key)
@@ -80,7 +80,7 @@ namespace LazyCache
 
             var item = CacheProvider.Get(key);
 
-            return GetValueFromAsyncLazy<T>(item);
+            return GetValueFromAsyncLazy<T>(item, out _);
         }
 
         public virtual T GetOrAdd<T>(string key, Func<ICacheEntry, T> addItemFactory)
@@ -88,17 +88,19 @@ namespace LazyCache
             ValidateKey(key);
 
             object cacheItem;
+
+            object CacheFactory(ICacheEntry entry) =>
+                new Lazy<T>(() =>
+                {
+                    var result = addItemFactory(entry);
+                    EnsureEvictionCallbackDoesNotReturnTheAsyncOrLazy<T>(entry.PostEvictionCallbacks);
+                    return result;
+                });
+
             locker.Wait(); //TODO: do we really need this? Could we just lock on the key?
             try
             {
-                cacheItem = CacheProvider.GetOrCreate<object>(key, entry =>
-                    new Lazy<T>(() =>
-                    {
-                        var result = addItemFactory(entry);
-                        EnsureEvictionCallbackDoesNotReturnTheAsyncOrLazy<T>(entry.PostEvictionCallbacks);
-                        return result;
-                    })
-                );
+                cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
             }
             finally
             {
@@ -107,7 +109,25 @@ namespace LazyCache
 
             try
             {
-                return GetValueFromLazy<T>(cacheItem);
+                var result =  GetValueFromLazy<T>(cacheItem, out var valueHasChangedType);
+
+                // if we get a cache hit but for something with the wrong type we need to evict it, start again and cache the new item instead
+                if (valueHasChangedType)
+                {
+                    CacheProvider.Remove(key);
+                    locker.Wait(); //TODO: do we really need this? Could we just lock on the key?
+                    try
+                    {
+                        cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
+                    }
+                    finally
+                    {
+                        locker.Release();
+                    }
+                    result = GetValueFromLazy<T>(cacheItem, out _ /* we just evicted so type change cannot happen this time */);
+                }
+
+                return result;
             }
             catch //addItemFactory errored so do not cache the exception
             {
@@ -138,16 +158,18 @@ namespace LazyCache
             await locker.WaitAsync()
                 .ConfigureAwait(
                     false); //TODO: do we really need to lock everything here - faster if we could lock on just the key?
+
+            object CacheFactory(ICacheEntry entry) =>
+                new AsyncLazy<T>(() =>
+                {
+                    var result = addItemFactory(entry);
+                    EnsureEvictionCallbackDoesNotReturnTheAsyncOrLazy<T>(entry.PostEvictionCallbacks);
+                    return result;
+                });
+
             try
             {
-                cacheItem = CacheProvider.GetOrCreate<object>(key, entry =>
-                    new AsyncLazy<T>(() =>
-                    {
-                        var result = addItemFactory(entry);
-                        EnsureEvictionCallbackDoesNotReturnTheAsyncOrLazy<T>(entry.PostEvictionCallbacks);
-                        return result;
-                    })
-                );
+                cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
             }
             finally
             {
@@ -156,7 +178,26 @@ namespace LazyCache
 
             try
             {
-                var result = GetValueFromAsyncLazy<T>(cacheItem);
+                var result = GetValueFromAsyncLazy<T>(cacheItem, out var valueHasChangedType);
+
+                // if we get a cache hit but for something with the wrong type we need to evict it, start again and cache the new item instead
+                if (valueHasChangedType)
+                {
+                    CacheProvider.Remove(key);
+                    await locker.WaitAsync()
+                        .ConfigureAwait(
+                            false); //TODO: do we really need to lock everything here - faster if we could lock on just the key?
+                    try
+                    {
+                        cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
+                    }
+                    finally
+                    {
+                        locker.Release();
+                    }
+                    result = GetValueFromAsyncLazy<T>(cacheItem, out _ /* we just evicted so type change cannot happen this time */);
+                }
+
 
                 if (result.IsCanceled || result.IsFaulted)
                     CacheProvider.Remove(key);
@@ -170,8 +211,9 @@ namespace LazyCache
             }
         }
 
-        protected virtual T GetValueFromLazy<T>(object item)
+        protected virtual T GetValueFromLazy<T>(object item, out bool valueHasChangedType)
         {
+            valueHasChangedType = false;
             switch (item)
             {
                 case Lazy<T> lazy:
@@ -187,11 +229,21 @@ namespace LazyCache
                     return task.Result;
             }
 
+            // if they have cached something else with the same key we need to tell caller to reset the cached item
+            // although this is probably not the fastest this should not get called on the main use case
+            // where you just hit the first switch case above. 
+            var itemsType = item?.GetType();
+            if (itemsType != null && itemsType.IsGenericType && itemsType.GetGenericTypeDefinition() == typeof(Lazy<>))
+            {
+                valueHasChangedType = true;
+            }
+
             return default(T);
         }
 
-        protected virtual Task<T> GetValueFromAsyncLazy<T>(object item)
+        protected virtual Task<T> GetValueFromAsyncLazy<T>(object item, out bool valueHasChangedType)
         {
+            valueHasChangedType = false; 
             switch (item)
             {
                 case AsyncLazy<T> asyncLazy:
@@ -203,6 +255,15 @@ namespace LazyCache
                     return Task.FromResult(lazy.Value);
                 case T variable:
                     return Task.FromResult(variable);
+            }
+
+            // if they have cached something else with the same key we need to tell caller to reset the cached item
+            // although this is probably not the fastest this should not get called on the main use case
+            // where you just hit the first switch case above. 
+            var itemsType = item?.GetType();
+            if (itemsType != null && itemsType.IsGenericType && itemsType.GetGenericTypeDefinition() == typeof(AsyncLazy<>))
+            {
+                valueHasChangedType = true;
             }
 
             return Task.FromResult(default(T));


### PR DESCRIPTION
Basically sensible use of lazy cache should not hit this - but if you are unusual and cache 2 incompatible types with one key this fixes the weirdness of unexpected nulls

fixes #46