### PR TITLE
Fix casing for PackageReference

### DIFF
--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath=""/>
-    <PackageReference Include="microsoft.extensions.caching.abstractions" Version="2.1.0" />
-    <PackageReference Include="microsoft.extensions.caching.memory" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This uses the *exact* names including casing.
Apparently C# build tooling partly cares about casing.

![image](https://user-images.githubusercontent.com/919634/92576371-bdfae800-f289-11ea-9954-9c6ba69d4426.png)

With this PR:
![image](https://user-images.githubusercontent.com/919634/92576801-382b6c80-f28a-11ea-8e8f-e08c74c0f84f.png)


For refence: I've opened https://github.com/dotnet/project-system/issues/6597