### PR TITLE
Remove async-await pair

### DIFF
--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -172,10 +172,11 @@ namespace LazyCache
 
         public virtual ICacheProvider CacheProvider => cacheProvider.Value;
 
-        public virtual async Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory)
+        public virtual Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory)
         {
-            return await GetOrAddAsync(key, addItemFactory, null);
+            return GetOrAddAsync(key, addItemFactory, null);
         }
+
         public virtual async Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory,
             MemoryCacheEntryOptions policy)
         { 


### PR DESCRIPTION
As `GetOrAddAsync` only calls the other `GetOrAddAsync` method with an extra `null` parameter it should not be necessary to `await` the call.
This also makes up for the a missing `ConfigureAwait(false)` introduced in https://github.com/alastairtree/LazyCache/commit/218bd2352b1217c9bacdf35566c19ebb3c85c7fa#diff-4a28b127c5a26901c14d4513be185990R165
