### PR TITLE
Policy should be supplied when refreshing the cache due to type mismatch

### DIFF
--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -137,7 +137,7 @@ namespace LazyCache
 
                     try
                     {
-                        cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
+                        cacheItem = CacheProvider.GetOrCreate<object>(key, policy, CacheFactory);
                     }
                     finally
                     {
@@ -226,7 +226,7 @@ namespace LazyCache
 
                     try
                     {
-                        cacheItem = CacheProvider.GetOrCreate<object>(key, CacheFactory);
+                        cacheItem = CacheProvider.GetOrCreate<object>(key, policy, CacheFactory);
                     }
                     finally
                     {


### PR DESCRIPTION
I have been struggling to get LazyCache to behave when setting a SizeLimit in the underlying MemoryCache. Intermittently it seemed, it would throw the following exception despite me supplying a size with the cache entry:
```
InvalidOperationException: Cache entry must specify a value for Size when SizeLimit is set.
```

Looking at the code, it appears in the situation where you have a type mis-match, the cache is refreshed however the supplied policy is not passed through which was causing the exception to be thrown.

I'm somewhat surprised no one has faced this before so I'm 70% sure I'm doing something wrong here. Consider this a very tentative PR ;)