### PR TITLE
Add GetCacheKeys() method to allow for partial key removal operations

### DIFF
--- a/Console.Net461/Program.cs
+++ b/Console.Net461/Program.cs
@@ -22,6 +22,15 @@ namespace Console.Net461
             item = cache.GetOrAdd("Program.Main.Person", () => Tuple.Create("Joe Blogs", DateTime.UtcNow));
 
             System.Console.WriteLine(item.Item1);
+
+            System.Console.WriteLine("Enumerating keys...");
+            foreach (var key in cache.GetCacheKeys().Keys)
+            {
+                System.Console.WriteLine($"{key}");
+            }
+            System.Console.WriteLine("Finished enumerating keys...");
+
+            System.Console.ReadLine();
         }
     }
 }

--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -1124,6 +1125,94 @@ namespace LazyCache.UnitTests
             var contains2 = sut.TryGetValue<string>("invalidkey", out var value2);
 
             Assert.IsFalse(contains2);
+        }
+
+        [Test]
+        public void ListOfCacheKeysContainsAllKeysAfterCallingAdd()
+        {
+            List<string> keys = new List<string>(){"one", "two", "three", "four", "five"};
+
+            
+            foreach (var key in keys)
+            {
+                sut.Add(key, key.Reverse());
+            }
+
+            var cachedKeys = sut.GetCacheKeys().Keys;
+
+            Assert.IsTrue(keys.Intersect(cachedKeys).Count() == keys.Count);
+        }
+
+        [Test]
+        public void ListOfCacheKeysContainsAllKeysAfterCallingGetOrAdd()
+        {
+            List<string> keys = new List<string>() { "one", "two", "three", "four", "five" };
+
+            foreach (var key in keys)
+            {
+                sut.GetOrAdd(key, () => key.Reverse());
+            }
+
+            var cachedKeys = sut.GetCacheKeys().Keys;
+
+            Assert.IsTrue(keys.Intersect(cachedKeys).Count() == keys.Count);
+        }
+
+        [Test]
+        public void ListOfCacheKeysContainsSomeKeysAfterCallingAddAndRemovingOne()
+        {
+            List<string> keys = new List<string>() { "one", "two", "three", "four", "five" };
+
+            foreach (var key in keys)
+            {
+                sut.Add(key, key.Reverse());
+            }
+
+            // remove three
+            sut.Remove("three");
+
+            var cachedKeys = sut.GetCacheKeys().Keys.ToList();
+
+            Assert.IsTrue(!cachedKeys.Contains("three"), "Three should be gone");
+        }
+
+        [Test]
+        public void ListOfCacheKeysContainsAllKeysAfterCallingGetOrAddAndRemovingOne()
+        {
+            List<string> keys = new List<string>() { "one", "two", "three", "four", "five" };
+
+            foreach (var key in keys)
+            {
+                sut.GetOrAdd(key, () => key.Reverse());
+            }
+
+            // remove three
+            sut.Remove("three");
+
+            var cachedKeys = sut.GetCacheKeys().Keys.ToList();
+
+            Assert.IsTrue(!cachedKeys.Contains("three"), "Three should be gone");
+        }
+
+        public void ListOfCacheKeysIsEmptyAfterRemovingThemAll()
+        {
+            List<string> keys = new List<string>() {"one", "two", "three", "four", "five"};
+
+            foreach (var key in keys)
+            {
+                sut.GetOrAdd(key, () => key.Reverse());
+            }
+
+            var cachedKeys = sut.GetCacheKeys().Keys.ToList();
+            Assert.IsTrue(keys.Intersect(cachedKeys).Count() == keys.Count);
+
+            foreach (var key in cachedKeys)
+            {
+                sut.Remove(key);
+            }
+
+            var cachedKeys2 = sut.GetCacheKeys().Keys.ToList();
+            Assert.AreEqual(cachedKeys2.Count, 0, "Should be zero keys left");
         }
     }
 }

--- a/LazyCache/CachedItemMeta.cs
+++ b/LazyCache/CachedItemMeta.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace LazyCache
+{
+    public class CachedItemMeta
+    {
+        public CachedItemMeta()
+        {
+            this.CreatedDate = DateTime.UtcNow;
+        }
+
+        public DateTime CreatedDate { get; set; }
+    }
+}

--- a/LazyCache/IAppCache.cs
+++ b/LazyCache/IAppCache.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -22,5 +23,6 @@ namespace LazyCache
         Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory);
         Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory, MemoryCacheEntryOptions policy);
         void Remove(string key);
+        Dictionary<string, CachedItemMeta> GetCacheKeys();
     }
 }

--- a/LazyCache/Mocks/MockCachingService.cs
+++ b/LazyCache/Mocks/MockCachingService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -11,6 +12,7 @@ namespace LazyCache.Mocks
     public class MockCachingService : IAppCache
     {
         public ICacheProvider CacheProvider { get; } = new MockCacheProvider();
+        
         public CacheDefaults DefaultCachePolicy { get; set; } = new CacheDefaults();
 
         public T Get<T>(string key)
@@ -56,6 +58,11 @@ namespace LazyCache.Mocks
         {
             value = default(T);
             return true;
+        }
+
+        public Dictionary<string, CachedItemMeta> GetCacheKeys()
+        {
+            return new Dictionary<string, CachedItemMeta>();
         }
     }
 }


### PR DESCRIPTION
I've read numerous requests to have a better mechanism to enumerate through keys that are stored in cache. This makes it very convenient to expire an entire set of cached items based on a prefixing pattern. While I understand there are various other ways to achieve this (like using cancellation tokens, or multiple caches) having access to a dictionary of keys makes for a very simple implementation.

Internally this maintains a ConcurrentDictionary with all of the cache keys, and a metadata object about each cached item. When calling `GetCacheKeys()` you get a copy of the key dictionary at a point in time. It's fully possible that a separate process changes the dictionary after the copy is taken. If the caller needs to prevent the dictionary from being modified while consuming the key dictionary that locking could be added external of LazyCache. For many use cases that level of control wouldn't be needed.

I've also added tests to demonstrate the dictionary working properly.