### PR TITLE
Wait for GetOrAddAsync factory to return before reading from AbsoluteExpirationRelativeToNow

### DIFF
--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -791,6 +791,48 @@ namespace LazyCache.UnitTests
         }
 
         [Test]
+        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateAfterCallingFactoryDoesExpireItems()
+        {
+            var millisecondsCacheDuration = 100;
+            var validResult = await sut.GetOrAddAsync(
+                TestKey,
+                async entry =>
+                {
+                    await Task.Delay(50);
+                    entry.SetAbsoluteExpiration(DateTimeOffset.Now.AddMilliseconds(millisecondsCacheDuration));
+                    return new ComplexTestObject();
+                }
+            );
+            // pass expiry time with a delay
+            Thread.Sleep(TimeSpan.FromMilliseconds(millisecondsCacheDuration + 50));
+            var expiredResult = sut.Get<ComplexTestObject>(TestKey);
+
+            Assert.That(validResult, Is.Not.Null);
+            Assert.That(expiredResult, Is.Null);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateUsingTimeSpanAfterCallingFactoryDoesExpireItems()
+        {
+            var millisecondsCacheDuration = 100;
+            var validResult = await sut.GetOrAddAsync(
+                TestKey,
+                async entry =>
+                {
+                    await Task.Delay(50);
+                    entry.SetAbsoluteExpiration(TimeSpan.FromMilliseconds(millisecondsCacheDuration));
+                    return new ComplexTestObject();
+                }
+            );
+            // pass expiry time with a delay
+            Thread.Sleep(TimeSpan.FromMilliseconds(millisecondsCacheDuration + 50));
+            var expiredResult = sut.Get<ComplexTestObject>(TestKey);
+
+            Assert.That(validResult, Is.Not.Null);
+            Assert.That(expiredResult, Is.Null);
+        }
+
+        [Test]
         public void GetOrAddWithCancellationExpiryBasedOnTimerAndCallbackInTheDelegateDoesExpireItemsAndFireTheCallback()
         {
             var millisecondsCacheDuration = 100;

--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -791,7 +791,7 @@ namespace LazyCache.UnitTests
         }
 
         [Test]
-        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateAfterCallingFactoryDoesExpireItems()
+        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateAfterLongRunningTaskDoesExpireItems()
         {
             var millisecondsCacheDuration = 100;
             var validResult = await sut.GetOrAddAsync(
@@ -812,7 +812,7 @@ namespace LazyCache.UnitTests
         }
 
         [Test]
-        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateUsingTimeSpanAfterCallingFactoryDoesExpireItems()
+        public async Task GetOrAddAsyncWithAbsoluteOffsetExpiryInTheDelegateUsingTimeSpanAfterLongRunningTaskDoesExpireItems()
         {
             var millisecondsCacheDuration = 100;
             var validResult = await sut.GetOrAddAsync(


### PR DESCRIPTION
Fixes #148.

- In `GetOrAddAsync`, `addItemFactory` is now `await`ed before `SetAbsoluteExpirationFromRelative` is called. This eliminates the race condition where `SetAbsoluteExpirationFromRelative` reads from `ICacheEntry.AbsoluteExpirationRelativeToNow` before it is set to, in cases where `AbsoluteExpirationRelativeToNow` is set after a long-running task in the factory completes.
- Added unit tests.