### PR TITLE
Use Generic type rather than object for TryGetValue

### DIFF
--- a/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
+++ b/LazyCache.UnitTests/CachingServiceMemoryCacheProviderTests.cs
@@ -1124,6 +1124,8 @@ namespace LazyCache.UnitTests
             var contains2 = sut.TryGetValue<string>("invalidkey", out var value2);
 
             Assert.IsFalse(contains2);
+
+            Assert.Throws<InvalidCastException>(() => sut.TryGetValue<int>(key, out var value3));
         }
     }
 }

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -89,7 +89,7 @@ namespace LazyCache
             return GetValueFromAsyncLazy<T>(item, out _);
         }
 
-        public virtual bool TryGetValue<T>(string key, out object value)
+        public virtual bool TryGetValue<T>(string key, out T value)
         {
             ValidateKey(key);
 

--- a/LazyCache/IAppCache.cs
+++ b/LazyCache/IAppCache.cs
@@ -15,7 +15,7 @@ namespace LazyCache
         void Add<T>(string key, T item, MemoryCacheEntryOptions policy);
         T Get<T>(string key);
         Task<T> GetAsync<T>(string key);
-        bool TryGetValue<T>(string key, out object value);
+        bool TryGetValue<T>(string key, out T value);
 
         T GetOrAdd<T>(string key, Func<ICacheEntry, T> addItemFactory);
         T GetOrAdd<T>(string key, Func<ICacheEntry, T> addItemFactory, MemoryCacheEntryOptions policy);

--- a/LazyCache/ICacheProvider.cs
+++ b/LazyCache/ICacheProvider.cs
@@ -12,6 +12,6 @@ namespace LazyCache
         object GetOrCreate<T>(string key, MemoryCacheEntryOptions policy, Func<ICacheEntry, T> func);
         void Remove(string key);
         Task<T> GetOrCreateAsync<T>(string key, Func<ICacheEntry, Task<T>> func);
-        bool TryGetValue(object key, out object value);
+        bool TryGetValue<T>(object key, out T value);
     }
 }

--- a/LazyCache/Mocks/MockCacheProvider.cs
+++ b/LazyCache/Mocks/MockCacheProvider.cs
@@ -35,7 +35,7 @@ namespace LazyCache.Mocks
             return func(null);
         }
 
-        public bool TryGetValue(object key, out object value)
+        public bool TryGetValue<T>(object key, out T value)
         {
             throw new NotImplementedException();
         }

--- a/LazyCache/Mocks/MockCachingService.cs
+++ b/LazyCache/Mocks/MockCachingService.cs
@@ -52,7 +52,7 @@ namespace LazyCache.Mocks
         {
         }
 
-        public bool TryGetValue<T>(string key, out object value)
+        public bool TryGetValue<T>(string key, out T value)
         {
             value = default(T);
             return true;

--- a/LazyCache/Providers/MemoryCacheProvider.cs
+++ b/LazyCache/Providers/MemoryCacheProvider.cs
@@ -78,7 +78,7 @@ namespace LazyCache.Providers
             return cache.GetOrCreateAsync(key, factory);
         }
 
-        public bool TryGetValue(object key, out object value)
+        public bool TryGetValue<T>(object key, out T value)
         {
             return cache.TryGetValue(key, out value);
         }


### PR DESCRIPTION
I noticed there was a comment about TryGetValue using T rather than object, and a PR was requested, but appears to not have been done.
I believe this PR will cover it.