### PR TITLE
Exposes Compact 

### DIFF
--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -43,7 +43,7 @@ namespace LazyCache
             = new Lazy<ICacheProvider>(() =>
                 new MemoryCacheProvider(
                     new MemoryCache(
-                        new MemoryCacheOptions() )
+                        new MemoryCacheOptions())
                 ));
 
         /// <summary>

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -43,7 +43,7 @@ namespace LazyCache
             = new Lazy<ICacheProvider>(() =>
                 new MemoryCacheProvider(
                     new MemoryCache(
-                        new MemoryCacheOptions())
+                        new MemoryCacheOptions() )
                 ));
 
         /// <summary>
@@ -183,6 +183,10 @@ namespace LazyCache
             return GetOrAddAsync(key, addItemFactory, null);
         }
 
+        public virtual void Compact(double percentage)
+        {
+            CacheProvider.Compact(percentage);
+        }
         public virtual async Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory,
             MemoryCacheEntryOptions policy)
         {

--- a/LazyCache/ICacheProvider.cs
+++ b/LazyCache/ICacheProvider.cs
@@ -13,5 +13,6 @@ namespace LazyCache
         void Remove(string key);
         Task<T> GetOrCreateAsync<T>(string key, Func<ICacheEntry, Task<T>> func);
         bool TryGetValue<T>(object key, out T value);
+        void Compact(double percentage);
     }
 }

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\artwork\logo-128.png" Pack="true" PackagePath=""/>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
+    <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -26,7 +26,7 @@
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -27,6 +27,7 @@
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -20,6 +20,7 @@
     <PackageTags>Caching Performance Speed In-memory IMemoryCache Generics ServiceCacheing Lazy Cache Lazy-Load MemoryCache CachingService AppCache ApplicationCache Memcached</PackageTags>
     <PackageReleaseNotes>See https://raw.githubusercontent.com/alastairtree/LazyCache/master/ReleaseNotes.md</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/LazyCache.csproj
+++ b/LazyCache/LazyCache.csproj
@@ -25,9 +25,9 @@
 
   <ItemGroup>
     <None Include="..\artwork\logo-128.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/LazyCache/Mocks/MockCacheProvider.cs
+++ b/LazyCache/Mocks/MockCacheProvider.cs
@@ -43,5 +43,10 @@ namespace LazyCache.Mocks
         public void Dispose()
         {
         }
+
+        public void Compact(double percentage)
+        {
+            
+        }
     }
 }

--- a/LazyCache/Providers/MemoryCacheProvider.cs
+++ b/LazyCache/Providers/MemoryCacheProvider.cs
@@ -88,5 +88,15 @@ namespace LazyCache.Providers
         {
             cache?.Dispose();
         }
+
+        public void Compact(double percentage)
+        {
+            if (cache is MemoryCache)
+            {
+                var c = cache as MemoryCache;
+                if (c != null)
+                    c.Compact(percentage);
+            }
+        }
     }
 }


### PR DESCRIPTION
For issue #171

Exposes Compact as found in MemoryCache. Other providers would have to implement or expose their own as ICacheProvider was changed.

From code comments in MemoryCache:
```
/// Remove at least the given percentage (0.10 for 10%) of the total entries (or estimated memory?), according to the following policy:
        /// 1. Remove all expired items.
        /// 2. Bucket by CacheItemPriority.
        /// 3. Least recently used objects.
        /// ?. Items with the soonest absolute expiration.
        /// ?. Items with the soonest sliding expiration.
        /// ?. Larger objects - estimated by object graph size, inaccurate.
```

[https://github.com/dotnet/runtime/blob/release/6.0/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs#L382-L393](url)