### PR TITLE
Fixed default cache duration not getting applied to instance methods

### DIFF
--- a/LazyCache.UnitTestsCore21/CachingServiceTests.cs
+++ b/LazyCache.UnitTestsCore21/CachingServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using LazyCache.Providers;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System;
 
 namespace LazyCache.UnitTestsCore21
 {
@@ -31,6 +33,54 @@ namespace LazyCache.UnitTestsCore21
 
             Assert.IsNotNull(cachedResult);
             Assert.AreEqual("SomeValue", cachedResult.SomeProperty);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncOnCore21DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public async Task GetOrAddOnCore21DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
         }
     }
 }

--- a/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
+++ b/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
+++ b/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
+++ b/LazyCache.UnitTestsCore21/LazyCache.UnitTestsCore21.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netcoreapp2.1</TargetFramework>
+	  <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore22/CachingServiceTests.cs
+++ b/LazyCache.UnitTestsCore22/CachingServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using LazyCache.Providers;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System;
 
 namespace LazyCache.UnitTestsCore22
 {
@@ -31,6 +33,54 @@ namespace LazyCache.UnitTestsCore22
 
             Assert.IsNotNull(cachedResult);
             Assert.AreEqual("SomeValue", cachedResult.SomeProperty);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncOnCore22DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public async Task GetOrAddOnCore22DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
         }
     }
 }

--- a/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
+++ b/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netcoreapp2.2</TargetFramework>
+	  <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
+++ b/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
+++ b/LazyCache.UnitTestsCore22/LazyCache.UnitTestsCore22.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore30/CachingServiceTests.cs
+++ b/LazyCache.UnitTestsCore30/CachingServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using LazyCache.Providers;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System;
 
 namespace LazyCache.UnitTestsCore30
 {
@@ -31,6 +33,54 @@ namespace LazyCache.UnitTestsCore30
 
             Assert.IsNotNull(cachedResult);
             Assert.AreEqual("SomeValue", cachedResult.SomeProperty);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncOnCore30DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public async Task GetOrAddOnCore30DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
         }
     }
 }

--- a/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
+++ b/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+	  <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
+++ b/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
+++ b/LazyCache.UnitTestsCore30/LazyCache.UnitTestsCore30.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netcoreapp3.0</TargetFramework>
+	  <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore31/CachingServiceTests.cs
+++ b/LazyCache.UnitTestsCore31/CachingServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using LazyCache.Providers;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System;
 
 namespace LazyCache.UnitTestsCore31
 {
@@ -31,6 +33,54 @@ namespace LazyCache.UnitTestsCore31
 
             Assert.IsNotNull(cachedResult);
             Assert.AreEqual("SomeValue", cachedResult.SomeProperty);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncOnCore31DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public async Task GetOrAddOnCore31DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
         }
     }
 }

--- a/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
+++ b/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+	  <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
+++ b/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>netcoreapp3.1</TargetFramework>
+	  <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
+++ b/LazyCache.UnitTestsCore31/LazyCache.UnitTestsCore31.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/LazyCache.UnitTestsNet50/CachingServiceTests.cs
+++ b/LazyCache.UnitTestsNet50/CachingServiceTests.cs
@@ -1,6 +1,8 @@
 ﻿using LazyCache.Providers;
 using Microsoft.Extensions.Caching.Memory;
 using NUnit.Framework;
+using System.Threading.Tasks;
+using System;
 
 namespace LazyCache.UnitTestsNet50
 {
@@ -31,6 +33,54 @@ namespace LazyCache.UnitTestsNet50
 
             Assert.IsNotNull(cachedResult);
             Assert.AreEqual("SomeValue", cachedResult.SomeProperty);
+        }
+
+        [Test]
+        public async Task GetOrAddAsyncOnNet50DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAddAsync("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+        }
+
+        [Test]
+        public async Task GetOrAddOnNet50DefaultCacheDurationHonoured()
+        {
+            sut.DefaultCachePolicy.DefaultCacheDurationSeconds = 1;
+
+            int value = DateTime.UtcNow.Second;
+            int result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+
+            Assert.AreEqual(value, result);
+
+            // wait for the item to expire
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            // same key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("foo", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
+
+            // new key
+            value = DateTime.UtcNow.Second;
+            result = await sut.GetOrAdd("bar", x => Task.FromResult(value));
+            Assert.AreEqual(value, result);
         }
     }
 }

--- a/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
+++ b/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
+++ b/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
+++ b/LazyCache.UnitTestsNet50/LazyCache.UnitTestsNet50.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net5.0</TargetFramework>
+	  <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LazyCache/CachingService.cs
+++ b/LazyCache/CachingService.cs
@@ -97,7 +97,7 @@ namespace LazyCache
 
         public virtual T GetOrAdd<T>(string key, Func<ICacheEntry, T> addItemFactory)
         {
-            return GetOrAdd(key, addItemFactory, null);
+            return GetOrAdd(key, addItemFactory, DefaultCachePolicy.BuildOptions());
         }
 
         public virtual T GetOrAdd<T>(string key, Func<ICacheEntry, T> addItemFactory, MemoryCacheEntryOptions policy)
@@ -180,7 +180,7 @@ namespace LazyCache
 
         public virtual Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory)
         {
-            return GetOrAddAsync(key, addItemFactory, null);
+            return GetOrAddAsync(key, addItemFactory, DefaultCachePolicy.BuildOptions());
         }
 
         public virtual async Task<T> GetOrAddAsync<T>(string key, Func<ICacheEntry, Task<T>> addItemFactory,


### PR DESCRIPTION
Changes:
- Fixed default cache duration not getting applied to instance methods
- Added unit tests